### PR TITLE
fix invocations of sudo

### DIFF
--- a/scripts/config
+++ b/scripts/config
@@ -91,9 +91,9 @@ get__display_subscribers() {
 get__subscribers_list() {
 
     # cf http://mlmmj.org/mlmmj-list.html
-    ynh_exec_as_app -- $install_dir/app/bin/mlmmj-list -L $install_dir/list -s
-    ynh_exec_as_app -- $install_dir/app/bin/mlmmj-list -L $install_dir/list -d
-    ynh_exec_as_app -- $install_dir/app/bin/mlmmj-list -L $install_dir/list -n
+    ynh_exec_as_app $install_dir/app/bin/mlmmj-list -L $install_dir/list -s
+    ynh_exec_as_app $install_dir/app/bin/mlmmj-list -L $install_dir/list -d
+    ynh_exec_as_app $install_dir/app/bin/mlmmj-list -L $install_dir/list -n
 
     echo ""
 }


### PR DESCRIPTION
## Problem

```
1088 WARNING env: ‘--’: No such file or directory
1105 WARNING env: ‘--’: No such file or directory
1120 WARNING env: ‘--’: No such file or directory
```

## Solution

autopatch left over broken syntax?

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
