### PR TITLE
Fix multiple mailing lists installation

### DIFF
--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -6,8 +6,8 @@ However, not all settings are available in this interface. It is possible to twe
 
 You can also run the various `mlmmj` commands from the CLI, such as
 
-- **List subscribers**: `sudo -u mlmmj -- __INSTALL_DIR__/app/bin/mlmmj-list -L __INSTALL_DIR__/list`
-- **Add a subscriber**: `sudo -u mlmmj -- __INSTALL_DIR__/app/bin/mlmmj-sub -L __INSTALL_DIR__/list -a sasha@domain.tld`
-- **Remove a subscriber**: `sudo -u mlmmj -- __INSTALL_DIR__/app/bin/mlmmj-unsub -L __INSTALL_DIR__/list -a sasha@domain.tld`
+- **List subscribers**: `sudo -u __APP__ -- __INSTALL_DIR__/app/bin/mlmmj-list -L __INSTALL_DIR__/list`
+- **Add a subscriber**: `sudo -u __APP__ -- __INSTALL_DIR__/app/bin/mlmmj-sub -L __INSTALL_DIR__/list -a sasha@domain.tld`
+- **Remove a subscriber**: `sudo -u __APP__ -- __INSTALL_DIR__/app/bin/mlmmj-unsub -L __INSTALL_DIR__/list -a sasha@domain.tld`
 
 More info about those commands can be obtained by adding the `-h` flag.

--- a/doc/ADMIN_fr.md
+++ b/doc/ADMIN_fr.md
@@ -6,8 +6,8 @@ Cependant, tous les paramètres ne sont pas disponibles depuis cette interface. 
 
 Il est également possible de gérer la liste depuis la ligne de commande de `mlmmj`, comme par exemple:
 
-- **Lister les abonné·e·s**: `sudo -u mlmmj -- __INSTALL_DIR__/app/bin/mlmmj-list -L __INSTALL_DIR__/list`
-- **Ajouter un abonnement**: `sudo -u mlmmj -- __INSTALL_DIR__/app/bin/mlmmj-sub -L __INSTALL_DIR__/list -a sasha@domain.tld`
-- **Supprimer un abonnement**: `sudo -u mlmmj -- __INSTALL_DIR__/app/bin/mlmmj-unsub -L __INSTALL_DIR__/list -a sasha@domain.tld`
+- **Lister les abonné·e·s**: `sudo -u __APP__ -- __INSTALL_DIR__/app/bin/mlmmj-list -L __INSTALL_DIR__/list`
+- **Ajouter un abonnement**: `sudo -u __APP__ -- __INSTALL_DIR__/app/bin/mlmmj-sub -L __INSTALL_DIR__/list -a sasha@domain.tld`
+- **Supprimer un abonnement**: `sudo -u __APP__ -- __INSTALL_DIR__/app/bin/mlmmj-unsub -L __INSTALL_DIR__/list -a sasha@domain.tld`
 
 Plus d'informations sur ces commandes peuvent être obtenuers en ajoutant l'option `-h`.

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -138,7 +138,7 @@ EOF
     touch "$install_dir/tables/transport"
     touch "$install_dir/tables/virtual"
 
-    local transport_entry="$app@localhost.mlmmj       mlmmj:$app"
+    local transport_entry="$app@localhost.mlmmj       $app:$app"
     local virtual_entry="$list_email    $app@localhost.mlmmj"
 
     if ! grep -qF "$transport_entry" "$install_dir/tables/transport"; then


### PR DESCRIPTION
## Problem

Previously when trying to install multiple mlmmj apps I found that I couldn't subscribe to the newly installed list properly

## Solution

After realizing that the corresponding user configuration is problematic, change the configuration of the transport_entry in _common.sh

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
